### PR TITLE
fix(codex): resolve hooks from session cwd

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/scripts/raven-tool-check.py\" --session-start",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/scripts/raven-tool-check.py --session-start",
             "timeout": 30,
             "statusMessage": "Checking RAVEN tool availability"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-pre-bash-guard.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-pre-bash-guard.py",
             "timeout": 30,
             "statusMessage": "Checking shell command safety"
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-pre-edit-guard.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-pre-edit-guard.py",
             "timeout": 30,
             "statusMessage": "Checking edit target"
           }
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-session-checkpoint.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-session-checkpoint.py",
             "timeout": 10,
             "statusMessage": "Validating session checkpoint"
           }
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-post-bash-summarize.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-post-bash-summarize.py",
             "timeout": 30,
             "statusMessage": "Checking shell output policy"
           }
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-post-edit-format.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-post-edit-format.py",
             "timeout": 30,
             "statusMessage": "Running lightweight formatter"
           }

--- a/.raven/manifest.json
+++ b/.raven/manifest.json
@@ -262,9 +262,9 @@
       "sourceSha256": "85a082d464427ccdc2fe0133dfc857981978fcb8627f95066fbd140e8dbdf64e"
     },
     ".codex/hooks.json": {
-      "installedSha256": "9a3996ba47dba46bc43d79ab60a3a8aaff8ee50af52c4e705d7b1edb30cb1f29",
+      "installedSha256": "11dddcd45a11a925da2755ac005b5b4b8783813e51038c6795fe02ba767e54e3",
       "kind": "file",
-      "sourceSha256": "9a3996ba47dba46bc43d79ab60a3a8aaff8ee50af52c4e705d7b1edb30cb1f29"
+      "sourceSha256": "11dddcd45a11a925da2755ac005b5b4b8783813e51038c6795fe02ba767e54e3"
     },
     ".codex/hooks/raven-post-bash-summarize.py": {
       "installedSha256": "3f584784bdec18cb6d3698307c98072c25355d933502864182a4a862cc55d3e0",
@@ -347,7 +347,7 @@
       "sourceSha256": "9e27c78e113022067d2e5c0e62901da5cc0a0ab1fe298a255ea6931424b3ab4e"
     },
     "AGENTS.md": {
-      "installedSha256": "ac42a062d792012ab2c227ce7bcaa8dff5b4d3c8971147b18e3f85fad45e756c",
+      "installedSha256": "c46c4bacbd089d583fc870a24126d510afd952e09ea1fa430c549fb54f4f4821",
       "kind": "file",
       "sourceSha256": "edcd8b2ace6c4187d9cc085770a9a0072bb260fdfb091ebba25b97bffe667dcf"
     },
@@ -368,8 +368,8 @@
       "sourceSha256": "b80f08d7da013bfb353f2311c5fd513aca2dd2e892fad350bcae930a9f024611"
     }
   },
-  "ravenVersion": "0de558a16c6f",
+  "ravenVersion": "d779fb8d48b4",
   "schema": 1,
   "template": "python",
-  "updatedAt": "2026-07-23T04:14:28.390700+00:00"
+  "updatedAt": "2026-07-26T09:19:19.817492+00:00"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Pause and ask before work that is ambiguous or could create durable harm:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **raven** (2460 symbols, 4606 relationships, 122 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **raven** (2467 symbols, 4623 relationships, 122 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/common/.codex/hooks.json
+++ b/common/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/scripts/raven-tool-check.py\" --session-start",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/scripts/raven-tool-check.py --session-start",
             "timeout": 30,
             "statusMessage": "Checking RAVEN tool availability"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-pre-bash-guard.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-pre-bash-guard.py",
             "timeout": 30,
             "statusMessage": "Checking shell command safety"
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-pre-edit-guard.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-pre-edit-guard.py",
             "timeout": 30,
             "statusMessage": "Checking edit target"
           }
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-session-checkpoint.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-session-checkpoint.py",
             "timeout": 10,
             "statusMessage": "Validating session checkpoint"
           }
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-post-bash-summarize.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-post-bash-summarize.py",
             "timeout": 30,
             "statusMessage": "Checking shell output policy"
           }
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"$(git rev-parse --show-toplevel)/.codex/hooks/raven-post-edit-format.py\"",
+            "command": "python -c \"import io,json,runpy,sys; from pathlib import Path; payload=sys.stdin.read(); relative=sys.argv[1]; cwd=Path(json.loads(payload)['cwd']).resolve(); root=next((path for path in (cwd,*cwd.parents) if (path/'.git').exists()), cwd); sys.stdin=io.StringIO(payload); sys.argv=sys.argv[1:]; runpy.run_path(str(root / relative), run_name='__main__')\" .codex/hooks/raven-post-edit-format.py",
             "timeout": 30,
             "statusMessage": "Running lightweight formatter"
           }

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3,6 +3,7 @@ import contextlib
 import io
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -230,7 +231,7 @@ paths = [".claude/skills/raven-plan/**"]
             ),
             (
                 REPO_ROOT / "common" / ".codex" / "hooks.json",
-                "$(git rev-parse --show-toplevel)/",
+                "json.loads(payload)['cwd']",
                 "python .codex/",
             ),
         ]
@@ -244,6 +245,78 @@ paths = [".claude/skills/raven-plan/**"]
                 for command in raven_commands:
                     self.assertIn(required_anchor, command)
                     self.assertNotIn(forbidden_prefix, command)
+
+    def test_codex_bash_guard_runs_outside_project_worktree(self):
+        config = json.loads(
+            (REPO_ROOT / "common" / ".codex" / "hooks.json").read_text(encoding="utf-8")
+        )
+        command = config["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        payload = {
+            "cwd": str(REPO_ROOT),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status --short"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                command,
+                cwd=tmp,
+                input=json.dumps(payload),
+                capture_output=True,
+                text=True,
+                shell=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_codex_hook_launcher_preserves_payload_and_arguments(self):
+        config = json.loads(
+            (REPO_ROOT / "common" / ".codex" / "hooks.json").read_text(encoding="utf-8")
+        )
+        command = config["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+        with tempfile.TemporaryDirectory() as project_tmp, tempfile.TemporaryDirectory() as cwd_tmp:
+            project = Path(project_tmp)
+            subprocess.run(
+                ["git", "init", "-q", str(project)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(project), "config", "core.bare", "true"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            script = project / ".codex" / "scripts" / "raven-tool-check.py"
+            script.parent.mkdir(parents=True)
+            script.write_text(
+                "import json, sys\n"
+                "print(json.dumps({'argv': sys.argv[1:], 'payload': json.load(sys.stdin)}))\n",
+                encoding="utf-8",
+            )
+            session_cwd = project / "nested" / "worktree"
+            session_cwd.mkdir(parents=True)
+            payload = {"cwd": str(session_cwd), "hook_event_name": "SessionStart"}
+
+            result = subprocess.run(
+                command,
+                cwd=cwd_tmp,
+                input=json.dumps(payload),
+                capture_output=True,
+                text=True,
+                shell=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["argv"], ["--session-start"])
+        self.assertEqual(output["payload"], payload)
 
     def test_templates_have_no_broken_symlinks(self):
         for language in raven.list_language_templates():


### PR DESCRIPTION
## Summary

- resolve Raven Codex hooks from the session `cwd` supplied in hook JSON rather than the hook process working directory
- locate the nearest repository `.git` marker without requiring Git to report a worktree
- preserve hook stdin and command-line arguments
- synchronize Raven dogfood output and manifest

## Verification

- focused regression tests reproduce launch from `/`, nested session directories, and `core.bare=true`
- `python scripts/self-check.py`
- pre-push: Ruff, Pyright, and 597 passing tests (1 skipped)
- local Timogin hook launch succeeds from `/` with nested session `cwd`

Closes #115