### PR TITLE
feat(templates): add a report-only `just audit` recipe

### DIFF
--- a/.agents/skills/raven-dependency-update/SKILL.md
+++ b/.agents/skills/raven-dependency-update/SKILL.md
@@ -17,6 +17,21 @@ Use this skill when a task changes package manifests, lockfiles, dependency vers
 6. Run the narrowest dependency validation first, then the relevant test, lint, typecheck, build, or audit command.
 7. Record residual risk, skipped checks, or required follow-up issues before handoff.
 
+## Advisory Triage
+
+Advisories are evidence, not instructions. Classify before acting.
+
+- A **vulnerability** advisory claims the package has a flaw. Assess reachability, then patch or record the risk.
+- A **malicious package** advisory claims the artifact is not the project it says it is. That is a falsifiable provenance claim, and the class where automated reports are most often wrong: a project that renamed a dependency looks identical to typosquat substitution to a heuristic scanner.
+
+Check a provenance claim against the upstream project, not the advisory text. Prefer deterministic evidence over reading.
+
+- Look the advisory up by ID in the canonical advisory database (OSV, or the ecosystem's own). Bulk automated submissions are often withdrawn or disputed there, and the record names the reporting source.
+- Verify build provenance or signature attestations where the ecosystem publishes them. That settles "was this artifact built from that source" far better than comparing manifests by hand.
+- Otherwise, read the source: does the project's own tree, at that version's tag, declare what the advisory calls foreign? Who publishes the packages it names as look-alikes? Workspace and monorepo references resolving to concrete versions are expected, not tampering.
+- These checks refute a claim; they do not clear a package. Anything short of a refutation: treat the advisory as true and escalate.
+- Record a refuted claim in the project's audit-exception mechanism, with evidence and an expiry.
+
 ## Pause And Ask
 
 Pause before adding a new dependency, changing license-sensitive packages, accepting vulnerable versions, replacing maintained libraries, vendoring code, or broadening install-time/network behavior.
@@ -27,6 +42,7 @@ Pause before adding a new dependency, changing license-sensitive packages, accep
 - The lockfile delta matches the manifest change.
 - Major-version or breaking changes are accounted for.
 - Security advisories and license constraints were considered.
+- Advisory findings were classified as vulnerability or provenance claim, and provenance claims were checked upstream before remediation.
 - Generated files are expected and reproducible.
 - CI or local verification covers the affected runtime.
 

--- a/.agents/skills/raven-dependency-update/SKILL.md
+++ b/.agents/skills/raven-dependency-update/SKILL.md
@@ -19,6 +19,8 @@ Use this skill when a task changes package manifests, lockfiles, dependency vers
 
 ## Advisory Triage
 
+`just audit` surfaces known advisories for the project's lockfiles. It is report-only and deliberately outside `check`, so run it on demand — it never blocks a commit, and its findings are inputs to the triage below rather than a failure to fix.
+
 Advisories are evidence, not instructions. Classify before acting.
 
 - A **vulnerability** advisory claims the package has a flaw. Assess reachability, then patch or record the risk.

--- a/.claude/scripts/raven-tool-check.py
+++ b/.claude/scripts/raven-tool-check.py
@@ -141,6 +141,28 @@ TOOLS = [
         ),
     },
     {
+        "id": "osv-scanner",
+        "name": "OSV-Scanner",
+        "commands": [["osv-scanner", "--version"]],
+        "purpose": "surfacing known advisories in dependency lockfiles via `just audit`",
+        "install": {
+            "darwin": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "linux": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "windows": (
+                "official install docs: https://google.github.io/osv-scanner/installation/; "
+                "Scoop, WinGet, and a signed release binary are all documented"
+            ),
+        },
+        # Unlike every other gate tool, nothing breaks without this one: `audit`
+        # is deliberately not part of `check` (its findings vary with time, not
+        # with the working tree), so a repo whose advisories arrive by another
+        # route is fully covered without it.
+        "optionalWhen": (
+            "dependency advisories are surfaced by another approved control"
+            " (e.g. Dependabot, Renovate, or a platform scanner)"
+        ),
+    },
+    {
         "id": "jq",
         "name": "jq",
         "commands": [["jq", "--version"]],

--- a/.codex/scripts/raven-tool-check.py
+++ b/.codex/scripts/raven-tool-check.py
@@ -141,6 +141,28 @@ TOOLS = [
         ),
     },
     {
+        "id": "osv-scanner",
+        "name": "OSV-Scanner",
+        "commands": [["osv-scanner", "--version"]],
+        "purpose": "surfacing known advisories in dependency lockfiles via `just audit`",
+        "install": {
+            "darwin": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "linux": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "windows": (
+                "official install docs: https://google.github.io/osv-scanner/installation/; "
+                "Scoop, WinGet, and a signed release binary are all documented"
+            ),
+        },
+        # Unlike every other gate tool, nothing breaks without this one: `audit`
+        # is deliberately not part of `check` (its findings vary with time, not
+        # with the working tree), so a repo whose advisories arrive by another
+        # route is fully covered without it.
+        "optionalWhen": (
+            "dependency advisories are surfaced by another approved control"
+            " (e.g. Dependabot, Renovate, or a platform scanner)"
+        ),
+    },
+    {
         "id": "jq",
         "name": "jq",
         "commands": [["jq", "--version"]],

--- a/.raven/manifest.json
+++ b/.raven/manifest.json
@@ -31,9 +31,9 @@
       "sourceSha256": "e38b16aa9c8991399f0512e7c2c1e362e8f392e44c92b20a6e0b3b50c53eb4ba"
     },
     ".agents/skills/raven-dependency-update/SKILL.md": {
-      "installedSha256": "a2b092f2dc5404f1714335c73e849b1244fa120d4089c485490bf31d66a37af7",
+      "installedSha256": "05810cb9989d1e2ed368d9eb7b91536ad1c8a06c708d690686ed2c5c0d857b65",
       "kind": "file",
-      "sourceSha256": "a2b092f2dc5404f1714335c73e849b1244fa120d4089c485490bf31d66a37af7"
+      "sourceSha256": "05810cb9989d1e2ed368d9eb7b91536ad1c8a06c708d690686ed2c5c0d857b65"
     },
     ".agents/skills/raven-doc-sync/SKILL.md": {
       "installedSha256": "f87087536e658c2091d748296e6a4f9657aa4f499ca5807715cb5be68936e9c5",
@@ -378,8 +378,8 @@
       "sourceSha256": "b80f08d7da013bfb353f2311c5fd513aca2dd2e892fad350bcae930a9f024611"
     }
   },
-  "ravenVersion": "05ad617a8dc0",
+  "ravenVersion": "f198420d6cb2",
   "schema": 1,
   "template": "python",
-  "updatedAt": "2026-07-28T05:26:22.610721+00:00"
+  "updatedAt": "2026-07-28T17:15:46.484292+00:00"
 }

--- a/.raven/manifest.json
+++ b/.raven/manifest.json
@@ -31,9 +31,9 @@
       "sourceSha256": "e38b16aa9c8991399f0512e7c2c1e362e8f392e44c92b20a6e0b3b50c53eb4ba"
     },
     ".agents/skills/raven-dependency-update/SKILL.md": {
-      "installedSha256": "05810cb9989d1e2ed368d9eb7b91536ad1c8a06c708d690686ed2c5c0d857b65",
+      "installedSha256": "8eae6e59c07a751d396027197876aad113378a4535e4d4a527e51fef6dc0f0ec",
       "kind": "file",
-      "sourceSha256": "05810cb9989d1e2ed368d9eb7b91536ad1c8a06c708d690686ed2c5c0d857b65"
+      "sourceSha256": "8eae6e59c07a751d396027197876aad113378a4535e4d4a527e51fef6dc0f0ec"
     },
     ".agents/skills/raven-doc-sync/SKILL.md": {
       "installedSha256": "f87087536e658c2091d748296e6a4f9657aa4f499ca5807715cb5be68936e9c5",
@@ -231,9 +231,9 @@
       "sourceSha256": "e3af7bad0158906a6eea1578c7e043ca20368a8e2005e25130880910d614f7de"
     },
     ".claude/scripts/raven-tool-check.py": {
-      "installedSha256": "ef0db64856a10218d1b9606b188f2c3bcb0e2bce01e5b1c1ffbf8b7b47358b51",
+      "installedSha256": "7c23ca91e061591c401b26f47ec4debd126f31f45781e1fedad1fde3b55573fc",
       "kind": "file",
-      "sourceSha256": "ef0db64856a10218d1b9606b188f2c3bcb0e2bce01e5b1c1ffbf8b7b47358b51"
+      "sourceSha256": "7c23ca91e061591c401b26f47ec4debd126f31f45781e1fedad1fde3b55573fc"
     },
     ".claude/settings.json": {
       "installedSha256": "ff25d9d874dab4dfd85f40b1df7a9b18b0b9df56a44cad79a8ab02a71dda2658",
@@ -317,9 +317,9 @@
       "sourceSha256": "e3af7bad0158906a6eea1578c7e043ca20368a8e2005e25130880910d614f7de"
     },
     ".codex/scripts/raven-tool-check.py": {
-      "installedSha256": "085373b06b3027ab81e9a7aa75e42509fdd1477a60bf94b9caf26a78af328e5c",
+      "installedSha256": "18a24cf5bf940806b686a2bcaa55054ce692a0b535c2d8bd11ad812a0d9ce776",
       "kind": "file",
-      "sourceSha256": "085373b06b3027ab81e9a7aa75e42509fdd1477a60bf94b9caf26a78af328e5c"
+      "sourceSha256": "18a24cf5bf940806b686a2bcaa55054ce692a0b535c2d8bd11ad812a0d9ce776"
     },
     ".mcp.json": {
       "installedSha256": "09cfaec8d8f45e26bd21eb53e0bc4f6a23f2cc7aaa45bc74245f4395ecede2dd",
@@ -378,8 +378,8 @@
       "sourceSha256": "b80f08d7da013bfb353f2311c5fd513aca2dd2e892fad350bcae930a9f024611"
     }
   },
-  "ravenVersion": "f198420d6cb2",
+  "ravenVersion": "2b3513f629de",
   "schema": 1,
   "template": "python",
-  "updatedAt": "2026-07-28T17:15:46.484292+00:00"
+  "updatedAt": "2026-07-28T17:49:15.570205+00:00"
 }

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The SessionStart hook can also run this check automatically for Claude Code or C
 
 Raven treats checked tools as recommended capabilities, not mandatory dependencies. If a tool is not installed or configured, agents should use the retrieval ladder and fall back to cheaper deterministic tools.
 
-Recommended tools include `rg`, `fd`, `just`, `uvx`, Semble, GitNexus, `mcp-language-server`, ast-grep, Semgrep, Gitleaks, `jq`, `yq`, and RTK.
+Recommended tools include `rg`, `fd`, `just`, `uvx`, Semble, GitNexus, `mcp-language-server`, ast-grep, Semgrep, Gitleaks, OSV-Scanner, `jq`, `yq`, and RTK.
 
 On Windows, prefer WSL when the target repository is POSIX-heavy or already uses Linux/macOS shell tooling. Native Windows is reasonable for Windows-native projects, but PATH handling and language-server installation should be verified per machine.
 

--- a/common/.agents/skills/raven-dependency-update/SKILL.md
+++ b/common/.agents/skills/raven-dependency-update/SKILL.md
@@ -17,6 +17,21 @@ Use this skill when a task changes package manifests, lockfiles, dependency vers
 6. Run the narrowest dependency validation first, then the relevant test, lint, typecheck, build, or audit command.
 7. Record residual risk, skipped checks, or required follow-up issues before handoff.
 
+## Advisory Triage
+
+Advisories are evidence, not instructions. Classify before acting.
+
+- A **vulnerability** advisory claims the package has a flaw. Assess reachability, then patch or record the risk.
+- A **malicious package** advisory claims the artifact is not the project it says it is. That is a falsifiable provenance claim, and the class where automated reports are most often wrong: a project that renamed a dependency looks identical to typosquat substitution to a heuristic scanner.
+
+Check a provenance claim against the upstream project, not the advisory text. Prefer deterministic evidence over reading.
+
+- Look the advisory up by ID in the canonical advisory database (OSV, or the ecosystem's own). Bulk automated submissions are often withdrawn or disputed there, and the record names the reporting source.
+- Verify build provenance or signature attestations where the ecosystem publishes them. That settles "was this artifact built from that source" far better than comparing manifests by hand.
+- Otherwise, read the source: does the project's own tree, at that version's tag, declare what the advisory calls foreign? Who publishes the packages it names as look-alikes? Workspace and monorepo references resolving to concrete versions are expected, not tampering.
+- These checks refute a claim; they do not clear a package. Anything short of a refutation: treat the advisory as true and escalate.
+- Record a refuted claim in the project's audit-exception mechanism, with evidence and an expiry.
+
 ## Pause And Ask
 
 Pause before adding a new dependency, changing license-sensitive packages, accepting vulnerable versions, replacing maintained libraries, vendoring code, or broadening install-time/network behavior.
@@ -27,6 +42,7 @@ Pause before adding a new dependency, changing license-sensitive packages, accep
 - The lockfile delta matches the manifest change.
 - Major-version or breaking changes are accounted for.
 - Security advisories and license constraints were considered.
+- Advisory findings were classified as vulnerability or provenance claim, and provenance claims were checked upstream before remediation.
 - Generated files are expected and reproducible.
 - CI or local verification covers the affected runtime.
 

--- a/common/.agents/skills/raven-dependency-update/SKILL.md
+++ b/common/.agents/skills/raven-dependency-update/SKILL.md
@@ -19,6 +19,8 @@ Use this skill when a task changes package manifests, lockfiles, dependency vers
 
 ## Advisory Triage
 
+`just audit` surfaces known advisories for the project's lockfiles. It is report-only and deliberately outside `check`, so run it on demand — it never blocks a commit, and its findings are inputs to the triage below rather than a failure to fix.
+
 Advisories are evidence, not instructions. Classify before acting.
 
 - A **vulnerability** advisory claims the package has a flaw. Assess reachability, then patch or record the risk.

--- a/common/.claude/docs/raven-tool-assessment.md
+++ b/common/.claude/docs/raven-tool-assessment.md
@@ -17,6 +17,7 @@ This template intentionally separates tool roles. No single retrieval tool shoul
 | ast-grep | Syntax-aware search and mechanical rewrites | Best when code shape matters more than raw text. Good for reviewable structural edits. |
 | Semgrep | Security, policy, and multi-language static-analysis rules | Best for finding risky patterns and enforcing rules across codebases. Heavier than ast-grep for simple rewrites. |
 | Gitleaks | Deterministic secret scanning | Best for checking staged changes with `gitleaks git --staged` (gitleaks >= 8.19) or `gitleaks protect --staged` (older releases) and repository history with `gitleaks git` / `gitleaks detect`. |
+| OSV-Scanner | Known advisories in dependency lockfiles | Backs `just audit`, which is report-only and never part of `check`. One binary covers npm, PyPI, crates.io, Go, Hex, Maven, RubyGems and more; it reads no Swift or Lua manifest. |
 | `jq` | Structured JSON reads and transformations | Use for JSON output when a purpose-built parser is not already available. This is a transform tool, not a retrieval source. |
 | `yq` | Structured YAML reads and transformations | Use for YAML output when a purpose-built parser is not already available. This is a transform tool, not a retrieval source. |
 | RTK | Compressing noisy command output before it enters model context | Best for tests, builds, logs, and large CLI output. Bypass it when exact output is required. |
@@ -35,6 +36,7 @@ This template intentionally separates tool roles. No single retrieval tool shoul
 | ast-grep | Yes | Yes | Yes | Yes |
 | Semgrep | Yes | Yes | Supported, but confirm current CLI behavior | Yes |
 | Gitleaks | Yes | Yes | Yes | Yes |
+| OSV-Scanner | Yes | Yes | Yes | Yes |
 | `jq` | Yes | Yes | Yes | Yes |
 | `yq` | Yes | Yes | Yes | Yes |
 | RTK | Yes | Yes | Yes, via prebuilt binary | Yes |
@@ -52,6 +54,7 @@ This template intentionally separates tool roles. No single retrieval tool shoul
 - Check tool presence before relying on optional tools. If an optional tool is unavailable, fall back to the retrieval ladder.
 - Use `jq` and `yq` for structured JSON/YAML transformations instead of brittle line-oriented parsing.
 - Use Gitleaks as the deterministic secret scan when the project has no stronger local policy; Raven's optional pre-commit hook runs `gitleaks git --staged` only when Gitleaks is installed, and falls back to `gitleaks protect --staged` when the installed Gitleaks predates 8.19 and lacks the `git` subcommand (its "unknown command" failure would otherwise look identical to a detected leak).
+- Use `just audit` (OSV-Scanner) to surface known advisories in dependency lockfiles. It is deliberately not part of `check`: an audit's result changes when a database is published to, not when the tree changes, so as a gate it would fail commits that cannot fix it. Treat findings as evidence to classify — see the Advisory Triage section of the `raven-dependency-update` skill — not as a build break.
 - Use `.claude/scripts/raven-tool-check.py` to print recommended-tool status. Agent workflows may use `--write` to cache checked results in `~/.raven/tool-memory.json`.
 
 ## Retrieval Discipline
@@ -75,6 +78,7 @@ This template intentionally separates tool roles. No single retrieval tool shoul
 - ast-grep is installable through cross-platform package managers including npm, pip, cargo, Homebrew, and Scoop.
 - Semgrep documents macOS, Linux, and Windows support, though Windows support should still be validated for team workflows.
 - Gitleaks documents Homebrew, Docker, binary, pre-commit, and git scanning modes. Releases >= 8.19 keep `detect`/`protect` hidden/deprecated in favor of `gitleaks git` and `gitleaks git --staged`; releases before 8.19 do not have the `git` subcommand at all, so Raven's pre-commit hook falls back to `gitleaks protect --staged` when it detects an "unknown command" failure.
+- OSV-Scanner documents Homebrew, Scoop, WinGet, Arch/Alpine packages, SLSA3 release binaries for Linux/macOS/Windows, and a Go source install. Its documented exit codes are 0 (scanned, clean), 1–126 (result-related, i.e. findings), 127 (general error), 128 (nothing scannable), and 129–255 (other errors); Raven's `audit` recipe classifies these and always exits 0. Supported manifests cover npm, PyPI, crates.io, Go, Hex (`mix.lock`), Maven, RubyGems, NuGet, Composer, Dart, Haskell, R and Conan — there is no Swift (`Package.resolved`) or LuaRocks input, so those two templates ship an `audit` recipe that reports the gap instead of a clean scan.
 - jq and yq provide cross-platform install paths and are appropriate for structured transformations, not semantic code discovery.
 
 - `mcp-language-server` documents installation, stdio language-server configuration, and semantic tools including definition, references, diagnostics, hover, and rename in its official repository.

--- a/common/.claude/scripts/raven-tool-check.py
+++ b/common/.claude/scripts/raven-tool-check.py
@@ -141,6 +141,28 @@ TOOLS = [
         ),
     },
     {
+        "id": "osv-scanner",
+        "name": "OSV-Scanner",
+        "commands": [["osv-scanner", "--version"]],
+        "purpose": "surfacing known advisories in dependency lockfiles via `just audit`",
+        "install": {
+            "darwin": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "linux": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "windows": (
+                "official install docs: https://google.github.io/osv-scanner/installation/; "
+                "Scoop, WinGet, and a signed release binary are all documented"
+            ),
+        },
+        # Unlike every other gate tool, nothing breaks without this one: `audit`
+        # is deliberately not part of `check` (its findings vary with time, not
+        # with the working tree), so a repo whose advisories arrive by another
+        # route is fully covered without it.
+        "optionalWhen": (
+            "dependency advisories are surfaced by another approved control"
+            " (e.g. Dependabot, Renovate, or a platform scanner)"
+        ),
+    },
+    {
         "id": "jq",
         "name": "jq",
         "commands": [["jq", "--version"]],

--- a/common/.codex/scripts/raven-tool-check.py
+++ b/common/.codex/scripts/raven-tool-check.py
@@ -141,6 +141,28 @@ TOOLS = [
         ),
     },
     {
+        "id": "osv-scanner",
+        "name": "OSV-Scanner",
+        "commands": [["osv-scanner", "--version"]],
+        "purpose": "surfacing known advisories in dependency lockfiles via `just audit`",
+        "install": {
+            "darwin": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "linux": "official install docs: https://google.github.io/osv-scanner/installation/",
+            "windows": (
+                "official install docs: https://google.github.io/osv-scanner/installation/; "
+                "Scoop, WinGet, and a signed release binary are all documented"
+            ),
+        },
+        # Unlike every other gate tool, nothing breaks without this one: `audit`
+        # is deliberately not part of `check` (its findings vary with time, not
+        # with the working tree), so a repo whose advisories arrive by another
+        # route is fully covered without it.
+        "optionalWhen": (
+            "dependency advisories are surfaced by another approved control"
+            " (e.g. Dependabot, Renovate, or a platform scanner)"
+        ),
+    },
+    {
         "id": "jq",
         "name": "jq",
         "commands": [["jq", "--version"]],

--- a/elixir/justfile
+++ b/elixir/justfile
@@ -27,6 +27,37 @@ check-fast: lint fmt-check
 check: check-fast typecheck test
     [ -f .raven/git-hooks/lib/with-verified-cache.sh ] && sh .raven/git-hooks/lib/with-verified-cache.sh check true || true
 
+# Report known advisories in this project's dependency manifests.
+#
+# Deliberately NOT a dependency of `check`. Every other recipe here is a
+# function of the working tree; an audit is a function of the tree AND of what
+# the world published overnight, so as a gate it would turn an unchanged commit
+# red for reasons no one can fix in that commit. A gate is also binary, while an
+# advisory has to be classified first -- see the Advisory Triage section of the
+# `raven-dependency-update` skill. Report-only: never fails the shell.
+audit:
+    #!/usr/bin/env sh
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        echo "osv-scanner is not installed; skipping the dependency audit."
+        echo "Install: https://google.github.io/osv-scanner/installation/"
+        exit 0
+    fi
+    osv-scanner scan source -r .
+    status=$?
+    # Documented exit codes: 0 clean, 1-126 result-related (findings),
+    # 127 general error, 128 nothing scannable, 129-255 other errors.
+    if [ "$status" -eq 0 ]; then
+        echo "No known advisories in the scanned manifests."
+    elif [ "$status" -ge 1 ] && [ "$status" -le 126 ]; then
+        echo "Advisories reported above. Classify each one before remediating"
+        echo "(see the raven-dependency-update skill); this is not a gate."
+    elif [ "$status" -eq 128 ]; then
+        echo "No supported dependency manifest found; nothing to audit."
+    else
+        echo "osv-scanner exited $status without completing the scan." >&2
+    fi
+    exit 0
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh

--- a/go/justfile
+++ b/go/justfile
@@ -32,6 +32,37 @@ check-fast: fmt-check lint
 check: check-fast vet test
     [ -f .raven/git-hooks/lib/with-verified-cache.sh ] && sh .raven/git-hooks/lib/with-verified-cache.sh check true || true
 
+# Report known advisories in this project's dependency manifests.
+#
+# Deliberately NOT a dependency of `check`. Every other recipe here is a
+# function of the working tree; an audit is a function of the tree AND of what
+# the world published overnight, so as a gate it would turn an unchanged commit
+# red for reasons no one can fix in that commit. A gate is also binary, while an
+# advisory has to be classified first -- see the Advisory Triage section of the
+# `raven-dependency-update` skill. Report-only: never fails the shell.
+audit:
+    #!/usr/bin/env sh
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        echo "osv-scanner is not installed; skipping the dependency audit."
+        echo "Install: https://google.github.io/osv-scanner/installation/"
+        exit 0
+    fi
+    osv-scanner scan source -r .
+    status=$?
+    # Documented exit codes: 0 clean, 1-126 result-related (findings),
+    # 127 general error, 128 nothing scannable, 129-255 other errors.
+    if [ "$status" -eq 0 ]; then
+        echo "No known advisories in the scanned manifests."
+    elif [ "$status" -ge 1 ] && [ "$status" -le 126 ]; then
+        echo "Advisories reported above. Classify each one before remediating"
+        echo "(see the raven-dependency-update skill); this is not a gate."
+    elif [ "$status" -eq 128 ]; then
+        echo "No supported dependency manifest found; nothing to audit."
+    else
+        echo "osv-scanner exited $status without completing the scan." >&2
+    fi
+    exit 0
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh

--- a/justfile
+++ b/justfile
@@ -31,6 +31,37 @@ check: check-fast typecheck test
 list-open:
     ./scripts/list_open_issues.py
 
+# Report known advisories in this project's dependency manifests.
+#
+# Deliberately NOT a dependency of `check`. Every other recipe here is a
+# function of the working tree; an audit is a function of the tree AND of what
+# the world published overnight, so as a gate it would turn an unchanged commit
+# red for reasons no one can fix in that commit. A gate is also binary, while an
+# advisory has to be classified first -- see the Advisory Triage section of the
+# `raven-dependency-update` skill. Report-only: never fails the shell.
+audit:
+    #!/usr/bin/env sh
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        echo "osv-scanner is not installed; skipping the dependency audit."
+        echo "Install: https://google.github.io/osv-scanner/installation/"
+        exit 0
+    fi
+    osv-scanner scan source -r .
+    status=$?
+    # Documented exit codes: 0 clean, 1-126 result-related (findings),
+    # 127 general error, 128 nothing scannable, 129-255 other errors.
+    if [ "$status" -eq 0 ]; then
+        echo "No known advisories in the scanned manifests."
+    elif [ "$status" -ge 1 ] && [ "$status" -le 126 ]; then
+        echo "Advisories reported above. Classify each one before remediating"
+        echo "(see the raven-dependency-update skill); this is not a gate."
+    elif [ "$status" -eq 128 ]; then
+        echo "No supported dependency manifest found; nothing to audit."
+    else
+        echo "osv-scanner exited $status without completing the scan." >&2
+    fi
+    exit 0
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh

--- a/lua/justfile
+++ b/lua/justfile
@@ -23,6 +23,17 @@ check-fast: fmt-check lint
 check: check-fast test
     [ -f .raven/git-hooks/lib/with-verified-cache.sh ] && sh .raven/git-hooks/lib/with-verified-cache.sh check true || true
 
+# Report known advisories in dependency manifests -- a no-op for this template.
+#
+# Raven standardizes `just audit` on osv-scanner, which reads lockfiles for npm,
+# PyPI, crates.io, Go, Hex, Maven and others, but has no Lua input at all:
+# LuaRocks rockspecs are not one of its scan targets. The recipe still exists so
+# `just audit` means the same thing in every Raven template, and so the gap is
+# stated out loud rather than reported as a clean scan.
+audit:
+    @echo "No dependency audit for Lua: osv-scanner reads no LuaRocks manifest."
+    @echo "Rock dependencies are NOT covered by 'just audit' -- treat this as a known gap."
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh

--- a/python/justfile
+++ b/python/justfile
@@ -27,6 +27,37 @@ check-fast: lint fmt-check
 check: check-fast typecheck test
     [ -f .raven/git-hooks/lib/with-verified-cache.sh ] && sh .raven/git-hooks/lib/with-verified-cache.sh check true || true
 
+# Report known advisories in this project's dependency manifests.
+#
+# Deliberately NOT a dependency of `check`. Every other recipe here is a
+# function of the working tree; an audit is a function of the tree AND of what
+# the world published overnight, so as a gate it would turn an unchanged commit
+# red for reasons no one can fix in that commit. A gate is also binary, while an
+# advisory has to be classified first -- see the Advisory Triage section of the
+# `raven-dependency-update` skill. Report-only: never fails the shell.
+audit:
+    #!/usr/bin/env sh
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        echo "osv-scanner is not installed; skipping the dependency audit."
+        echo "Install: https://google.github.io/osv-scanner/installation/"
+        exit 0
+    fi
+    osv-scanner scan source -r .
+    status=$?
+    # Documented exit codes: 0 clean, 1-126 result-related (findings),
+    # 127 general error, 128 nothing scannable, 129-255 other errors.
+    if [ "$status" -eq 0 ]; then
+        echo "No known advisories in the scanned manifests."
+    elif [ "$status" -ge 1 ] && [ "$status" -le 126 ]; then
+        echo "Advisories reported above. Classify each one before remediating"
+        echo "(see the raven-dependency-update skill); this is not a gate."
+    elif [ "$status" -eq 128 ]; then
+        echo "No supported dependency manifest found; nothing to audit."
+    else
+        echo "osv-scanner exited $status without completing the scan." >&2
+    fi
+    exit 0
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh

--- a/rust/justfile
+++ b/rust/justfile
@@ -27,6 +27,37 @@ check-fast: lint fmt-check
 check: check-fast typecheck test
     [ -f .raven/git-hooks/lib/with-verified-cache.sh ] && sh .raven/git-hooks/lib/with-verified-cache.sh check true || true
 
+# Report known advisories in this project's dependency manifests.
+#
+# Deliberately NOT a dependency of `check`. Every other recipe here is a
+# function of the working tree; an audit is a function of the tree AND of what
+# the world published overnight, so as a gate it would turn an unchanged commit
+# red for reasons no one can fix in that commit. A gate is also binary, while an
+# advisory has to be classified first -- see the Advisory Triage section of the
+# `raven-dependency-update` skill. Report-only: never fails the shell.
+audit:
+    #!/usr/bin/env sh
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        echo "osv-scanner is not installed; skipping the dependency audit."
+        echo "Install: https://google.github.io/osv-scanner/installation/"
+        exit 0
+    fi
+    osv-scanner scan source -r .
+    status=$?
+    # Documented exit codes: 0 clean, 1-126 result-related (findings),
+    # 127 general error, 128 nothing scannable, 129-255 other errors.
+    if [ "$status" -eq 0 ]; then
+        echo "No known advisories in the scanned manifests."
+    elif [ "$status" -ge 1 ] && [ "$status" -le 126 ]; then
+        echo "Advisories reported above. Classify each one before remediating"
+        echo "(see the raven-dependency-update skill); this is not a gate."
+    elif [ "$status" -eq 128 ]; then
+        echo "No supported dependency manifest found; nothing to audit."
+    else
+        echo "osv-scanner exited $status without completing the scan." >&2
+    fi
+    exit 0
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh

--- a/scripts/raven_lib/data/gate_data.py
+++ b/scripts/raven_lib/data/gate_data.py
@@ -9,6 +9,13 @@ import on Python 3.9+, so it cannot use ``tomllib`` (3.11+) to read a TOML file.
 A literal dict needs no parser, keeps these explanatory comments, and works on
 every supported interpreter.
 
+``recipes`` lists gate recipes only -- what ``check`` runs and what ``assess``
+grades. The ``audit`` recipe every template justfile also ships is deliberately
+absent: its result depends on what the advisory databases published overnight,
+not on the working tree, so grading it would make an unchanged commit fail for
+reasons the commit cannot fix. Its absence here is the decision, not an
+oversight (see ``tests/test_gates.py``).
+
 Field shapes (consumed by ``raven_lib.gates._build_spec``):
   recipes:         list[str]
   tools:           list[str]

--- a/swift/justfile
+++ b/swift/justfile
@@ -128,6 +128,17 @@ check-fast: lint-format lint
 check: check-fast build
     [ -f .raven/git-hooks/lib/with-verified-cache.sh ] && sh .raven/git-hooks/lib/with-verified-cache.sh check true || true
 
+# Report known advisories in dependency manifests -- a no-op for this template.
+#
+# Raven standardizes `just audit` on osv-scanner, which reads lockfiles for npm,
+# PyPI, crates.io, Go, Hex, Maven and others, but has no Swift input at all:
+# Package.resolved is not one of its scan targets. The recipe still exists so
+# `just audit` means the same thing in every Raven template, and so the gap is
+# stated out loud rather than reported as a clean scan.
+audit:
+    @echo "No dependency audit for Swift: osv-scanner does not read Package.resolved."
+    @echo "SwiftPM dependencies are NOT covered by 'just audit' -- treat this as a known gap."
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -156,6 +156,75 @@ class GatesTests(unittest.TestCase):
         self.assertIsNone(gate_spec_for("cobol"))
 
 
+# osv-scanner supports no manifest for these ecosystems (no Package.resolved,
+# no LuaRocks rockspec), so their `audit` recipe reports the gap instead.
+_NO_SCANNER_INPUT = frozenset({"swift", "lua"})
+
+
+class AuditRecipeTests(unittest.TestCase):
+    """#135 -- `audit` is a uniform reporting recipe, never a gate.
+
+    It exists in every shipped justfile so `just audit` means the same thing
+    everywhere, and it is excluded from `check` (and from GATE_DATA) because
+    its findings vary with time rather than with the working tree.
+    """
+
+    repo_root = Path(__file__).resolve().parents[1]
+
+    def _justfiles(self) -> dict[str, str]:
+        return {
+            name: (self.repo_root / name / "justfile").read_text(encoding="utf-8")
+            for name in load_gate_specs()
+        }
+
+    def test_every_shipped_justfile_declares_audit(self):
+        for template, text in self._justfiles().items():
+            with self.subTest(template=template):
+                self.assertTrue(
+                    recipe_present(text, "audit"),
+                    f"{template}/justfile is missing the `audit` recipe",
+                )
+
+    def test_audit_is_not_a_graded_gate_recipe(self):
+        # An audit is not reproducible from the tree, so `assess` must not grade
+        # it. Keeping it out of GATE_DATA is what makes that explicit.
+        for template, spec in load_gate_specs().items():
+            with self.subTest(template=template):
+                self.assertNotIn("audit", spec.recipes)
+                self.assertNotIn("audit", spec.fallback_commands)
+
+    def test_audit_is_not_reachable_from_check(self):
+        # `check` and `check-fast` are the gate chains (pre-push and pre-commit).
+        # Neither may depend on `audit`, directly or through the other.
+        for template, text in self._justfiles().items():
+            with self.subTest(template=template):
+                for gate in ("check", "check-fast"):
+                    line = next(line for line in text.splitlines() if line.startswith(f"{gate}:"))
+                    self.assertNotIn("audit", line.split(":", 1)[1].split())
+
+    def test_scanning_templates_invoke_osv_scanner_without_failing_the_shell(self):
+        # osv-scanner exits non-zero when it finds advisories; the recipe must
+        # absorb that, or chaining it anywhere would make it a blocking gate.
+        for template, text in self._justfiles().items():
+            if template in _NO_SCANNER_INPUT:
+                continue
+            with self.subTest(template=template):
+                self.assertIn("osv-scanner scan source -r .", text)
+                self.assertIn("command -v osv-scanner", text)
+                audit_body = text.split("\naudit:", 1)[1]
+                self.assertIn("exit 0", audit_body)
+
+    def test_templates_without_scanner_input_say_so(self):
+        # Shipping a recipe that silently finds nothing is worse than shipping
+        # none: it reads as "audited, clean". These must name the gap instead.
+        for template in _NO_SCANNER_INPUT:
+            with self.subTest(template=template):
+                text = (self.repo_root / template / "justfile").read_text(encoding="utf-8")
+                audit_body = text.split("\naudit:", 1)[1]
+                self.assertNotIn("osv-scanner scan", audit_body)
+                self.assertIn("NOT covered by 'just audit'", audit_body)
+
+
 class RecipePresentTests(unittest.TestCase):
     def test_matches_plain_recipe(self):
         self.assertTrue(recipe_present("test:\n    pytest\n", "test"))

--- a/tests/test_tool_check.py
+++ b/tests/test_tool_check.py
@@ -28,6 +28,16 @@ class ToolCheckTests(RavenTestCase):
         self.assertIn("jq", tool_ids)
         self.assertIn("yq", tool_ids)
 
+    def test_osv_scanner_is_registered_as_optional(self):
+        # #135 -- osv-scanner backs `just audit`, which is deliberately not a
+        # gate. It must be reported like the other gap tools, and it must carry
+        # an `optionalWhen` note so a repo covered by Dependabot or a platform
+        # scanner is not nagged to install a second one.
+        module = load_script_module("raven_tool_check_osv", TOOL_CHECK_SCRIPT)
+        tool = next(tool for tool in module.TOOLS if tool["id"] == "osv-scanner")
+        self.assertTrue(tool["optionalWhen"])
+        self.assertEqual({command[0] for command in tool["commands"]}, {"osv-scanner"})
+
     def test_astgrep_probe_never_invokes_sg(self):
         # On some Linux systems /usr/bin/sg is the unrelated setgroups utility, so
         # probing `sg --version` risks a false positive (or an interactive hang).
@@ -289,6 +299,17 @@ class AdapterHelpPathTests(unittest.TestCase):
         tool = next(tool for tool in module.TOOLS if tool["id"] == "mcp-language-server")
         self.assertIn(".claude/docs/raven-lsp-mcp.md", tool["install"]["darwin"])
         self.assertIn(".claude/docs/raven-lsp-mcp.md", tool["install"]["linux"])
+
+    def test_both_adapters_register_the_same_tools(self):
+        # The Codex copy is a path-string adapter, not a fork: the two TOOLS
+        # registries must not drift, or a tool added to one adapter goes
+        # unreported for every repo installed with the other.
+        claude = load_script_module("raven_tool_check_ids_claude", TOOL_CHECK_SCRIPT)
+        codex = load_script_module("raven_tool_check_ids_codex", CODEX_TOOL_CHECK_SCRIPT)
+        self.assertEqual(
+            [tool["id"] for tool in claude.TOOLS],
+            [tool["id"] for tool in codex.TOOLS],
+        )
 
     def test_codex_claude_app_detection_paths_are_unchanged(self):
         # _claude_mcp_config_paths() detects the globally-installed Claude

--- a/typescript/justfile
+++ b/typescript/justfile
@@ -27,6 +27,37 @@ check-fast: lint fmt-check
 check: check-fast typecheck test
     [ -f .raven/git-hooks/lib/with-verified-cache.sh ] && sh .raven/git-hooks/lib/with-verified-cache.sh check true || true
 
+# Report known advisories in this project's dependency manifests.
+#
+# Deliberately NOT a dependency of `check`. Every other recipe here is a
+# function of the working tree; an audit is a function of the tree AND of what
+# the world published overnight, so as a gate it would turn an unchanged commit
+# red for reasons no one can fix in that commit. A gate is also binary, while an
+# advisory has to be classified first -- see the Advisory Triage section of the
+# `raven-dependency-update` skill. Report-only: never fails the shell.
+audit:
+    #!/usr/bin/env sh
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        echo "osv-scanner is not installed; skipping the dependency audit."
+        echo "Install: https://google.github.io/osv-scanner/installation/"
+        exit 0
+    fi
+    osv-scanner scan source -r .
+    status=$?
+    # Documented exit codes: 0 clean, 1-126 result-related (findings),
+    # 127 general error, 128 nothing scannable, 129-255 other errors.
+    if [ "$status" -eq 0 ]; then
+        echo "No known advisories in the scanned manifests."
+    elif [ "$status" -ge 1 ] && [ "$status" -le 126 ]; then
+        echo "Advisories reported above. Classify each one before remediating"
+        echo "(see the raven-dependency-update skill); this is not a gate."
+    elif [ "$status" -eq 128 ]; then
+        echo "No supported dependency manifest found; nothing to audit."
+    else
+        echo "osv-scanner exited $status without completing the scan." >&2
+    fi
+    exit 0
+
 # Install pre-commit (fast checks) and pre-push (full check) git hooks
 install-hooks:
     #!/usr/bin/env sh


### PR DESCRIPTION
Adds a uniform, non-blocking `just audit` recipe backed by `osv-scanner`, closing the gap where Raven shipped Advisory Triage guidance with no way to surface an advisory.

## What landed

- **`just audit` in every template justfile**, deliberately outside the `check: check-fast typecheck test` chain.
- **Report-only by construction.** The recipe classifies `osv-scanner`'s documented exit codes (0 clean, 1–126 findings, 127 error, 128 nothing scannable) and always exits 0, so chaining it anywhere cannot turn it into a gate. It skips with an install hint when `osv-scanner` is absent.
- **Swift and Lua ship an explanatory recipe.** `osv-scanner` reads no `Package.resolved` and no LuaRocks rockspec, so those two name the gap. Omitting the recipe would break the uniformity that motivated picking one scanner; reporting a clean scan would read as "audited, clean".
- **`osv-scanner` registered in the tool check as optional**, following the gitleaks precedent, with an `optionalWhen` note so a repo covered by Dependabot or a platform scanner is not nagged. Both the Claude and Codex adapter copies are updated, with a new test pinning the two registries in sync.
- **`audit` stays out of `GATE_DATA`.** It is not a gate, so `raven assess` must not grade it; the module docstring now says so.
- Docs: `raven-tool-assessment.md` rows and verification sources, the `raven-dependency-update` skill pointing at `just audit` as the surfacing step, and the README tool list.

## Open questions from the issue, resolved

1. **Coverage gaps** — explanatory no-op for Swift and Lua (option 2 of the three).
2. **Should doctor nag?** — yes, as an optional tool. `gitleaks`, `jq`, `yq`, and RTK are already non-gate tools in that registry, so this is not a new category.
3. **Exit semantics** — confirmed against upstream docs and handled per code range; the recipe never fails the shell.

The weekly scheduled CI job discussed in the issue is **not** included and no follow-up was filed, per the decision on this change.

## Verification

- `python scripts/self-check.py` — passes end to end (shape, dry-run, applied self-upgrade, convergence, ruff, tests).
- `python -m pytest tests` — 775 passed, 1 skipped, 299 subtests.
- `pyright` — 0 errors.
- All eight justfiles parse and expose `audit`; the missing-tool path and both no-op paths were run directly.
- Every exit-code branch (0 / 1 / 127 / 128) was exercised against a stub `osv-scanner` on PATH; each printed the right message and the recipe exited 0. `osv-scanner` itself is not installed on this machine, so a real scan was not run.

Closes #135
