### PR TITLE
feat(git-hooks): gate commit-message trailers on push

### DIFF
--- a/.raven/git-hooks/lib/check-ai-attribution-content.py
+++ b/.raven/git-hooks/lib/check-ai-attribution-content.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Block AI attribution mentions from leaking into staged/outbound file content.
+"""Block AI attribution mentions from leaking into staged/outbound content.
 
-The commit-msg hook only cleans commit *message* trailers -- an AI-authorship
-credit left in a source file or README (an AI tool named as the generator)
-would still reach history untouched. Unlike commit-msg, this fails the
-commit/push rather than silently editing tracked file content: there is no
+The commit-msg hook strips attribution *trailers* at commit time -- but an
+AI-authorship credit left in a source file or README (an AI tool named as the
+generator) would still reach history untouched. Unlike commit-msg, this fails
+the commit/push rather than silently editing tracked file content: there is no
 safe way to auto-rewrite an arbitrary line inside a source file.
+
+The `outbound --push-plan` path additionally scans commit *messages*, which
+commit-msg cannot vouch for. Stripping only happens when that hook ran, and it
+routinely does not: `git commit --no-verify`, `git cherry-pick` and `git
+rebase` reapplying pre-hook commits (neither runs commit-msg), and any clone
+made before the hooks were installed all land a trailer in history that
+strip-time never saw. Pre-push is where that is discoverable.
 
 Modes:
 
@@ -41,6 +48,20 @@ _CONTENT_PATTERN = re.compile(
     r"(?:generated|written|authored|implemented|drafted)\s+(?:by|with)\s+.*"
     r"(?:claude|copilot|codex|chatgpt|gpt-[0-9]+|gemini|llama|mistral"
     r"|@anthropic\.com|@openai\.com)",
+    re.IGNORECASE,
+)
+
+# Commit-message trailers, matched per line. Deliberately a copy of the
+# commit-msg hook's `_AI_TRAILER` rather than an import: that hook is a
+# standalone script with no dependency on this lib/ directory, and a partial
+# install must not be able to break it. `test_message_pattern_matches_the_
+# commit_msg_hook_pattern` pins the two together so they cannot drift.
+_MESSAGE_PATTERN = re.compile(
+    r"^(?:co-authored-by|generated-by):\s+.*"
+    r"(?:(?:claude|copilot|codex|chatgpt|gpt-[0-9]+|gemini|llama|mistral"
+    r"|@anthropic\.com|@openai\.com)"
+    r"|<noreply@[^>]+>)"
+    r"|^claude-session:\s+\S+",
     re.IGNORECASE,
 )
 
@@ -100,6 +121,21 @@ def _scan(added_lines: list[str], label: str) -> int:
         print(hit, file=sys.stderr)
     print(
         "remove generated-attribution mentions from newly added repository text",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _scan_messages(message_text: str, label: str) -> int:
+    hits = [line for line in message_text.splitlines() if _MESSAGE_PATTERN.match(line)]
+    if not hits:
+        return 0
+    print(f"Forbidden AI attribution trailer found in a commit message ({label}):", file=sys.stderr)
+    for hit in hits:
+        print(hit, file=sys.stderr)
+    print(
+        "amend or rebase the commit to drop the attribution trailer "
+        "(commit-msg strips these, but only when it runs)",
         file=sys.stderr,
     )
     return 1
@@ -174,6 +210,16 @@ def _remote_tracking_shas(remote: str) -> list[str]:
     return every.stdout.split()
 
 
+_UNBOUNDED_NOTICE = (
+    "note: no remote baseline -- this remote has no tracking refs in this clone, "
+    "so nothing is known to be already published and the scan covered the full "
+    "history rather than only new commits. The findings above may predate this "
+    "branch and may not be fixable without rewriting history. To publish anyway, "
+    "set block_ai_attribution_content = false under [git_hooks] in "
+    ".raven/config.toml."
+)
+
+
 def _scan_push_plan(plan_text: str, remote: str) -> int:
     """Scan the commits Git is actually pushing, per its own push plan.
 
@@ -196,6 +242,20 @@ def _scan_push_plan(plan_text: str, remote: str) -> int:
     that branch's content as newly added. The trade-off is that a merge commit
     contributes no patch of its own, leaving content introduced solely by a
     conflict resolution to the staged (pre-commit) scan.
+
+    The same revision set is scanned twice: once for file content and once for
+    commit messages, which the commit-msg hook can only vouch for on commits it
+    actually ran on.
+
+    When the remote has no tracking refs at all, the negative side is empty and
+    the walk does reach the root commit. That is intentional and pinned by test:
+    nothing is known to be published, so every reachable commit genuinely is
+    leaving the machine for the first time and scanning all of it is the correct
+    answer rather than a false positive. It is not the fail-open case -- the
+    scan is fully evaluable, just wide -- so findings are reported, with
+    `_UNBOUNDED_NOTICE` explaining why they may reach further back than the
+    push. Only unevaluable states (unresolvable object, failing git invocation)
+    skip.
     """
     positives: list[str] = []
     negatives: list[str] = []
@@ -221,16 +281,34 @@ def _scan_push_plan(plan_text: str, remote: str) -> int:
     # An exclusion tip that equals a pushed tip is kept, not dropped: it means the
     # remote already has that commit (e.g. pushing an existing tip under a new
     # branch name), and the correct outcome is an empty scan, not a full rescan.
-    args = ["log", "--no-color", "--format=%H", "--unified=0", "-p", *dict.fromkeys(positives)]
-    if negatives:
-        args += ["--not", *dict.fromkeys(negatives)]
-    args += ["--", "."]
-    log = _git(args)
-    if log.returncode != 0:
+    revs = list(dict.fromkeys(positives))
+    bounds = ["--not", *dict.fromkeys(negatives)] if negatives else []
+    label = f"outbound commits for {', '.join(pushed_refs)}"
+
+    content = _git(
+        ["log", "--no-color", "--format=%H", "--unified=0", "-p", *revs, *bounds, "--", "."]
+    )
+    if content.returncode != 0:
         # git could not walk the range (e.g. a corrupt or grafted object); skip
         # rather than block a push this hook cannot evaluate.
         return 0
-    return _scan(_added_lines(log.stdout), f"outbound commits for {', '.join(pushed_refs)}")
+    content_status = _scan(_added_lines(content.stdout), label)
+
+    # Messages get their own invocation rather than a widened --format on the one
+    # above: keeping the two streams apart means no delimiter has to survive
+    # adversarial patch text, and no patch line can be read as a message (or the
+    # reverse). No pathspec here -- every pushed commit's message counts,
+    # including a merge's, which contributes no patch of its own.
+    messages = _git(["log", "--no-color", "--no-patch", "--format=%B", *revs, *bounds])
+    message_status = 0
+    if messages.returncode == 0:
+        message_status = _scan_messages(messages.stdout, label)
+
+    if not (content_status or message_status):
+        return 0
+    if not bounds:
+        print(_UNBOUNDED_NOTICE, file=sys.stderr)
+    return 1
 
 
 _USAGE = "usage: check-ai-attribution-content.py {staged|outbound} [--push-plan] [--remote NAME]"

--- a/.raven/manifest.json
+++ b/.raven/manifest.json
@@ -332,9 +332,9 @@
       "sourceSha256": "4e43568c8d9fade8203692e4d34b8804d9e19fe78de06356b7538e85473e128b"
     },
     ".raven/git-hooks/lib/check-ai-attribution-content.py": {
-      "installedSha256": "3b644125608a67b7e00378a79d8a0a526b50b25a414f307f1829f65cc9632e0f",
+      "installedSha256": "55aa24b63b41e8c94bb5463d9848ad2fbf4b9f306faf37b7ac0c7505c01b5aaa",
       "kind": "file",
-      "sourceSha256": "3b644125608a67b7e00378a79d8a0a526b50b25a414f307f1829f65cc9632e0f"
+      "sourceSha256": "55aa24b63b41e8c94bb5463d9848ad2fbf4b9f306faf37b7ac0c7505c01b5aaa"
     },
     ".raven/git-hooks/lib/check-managed-block-integrity.py": {
       "installedSha256": "40e273b6fc63d62cabe26118eb549d31721ed16bb476a4f566efe67d049fcb46",
@@ -378,8 +378,8 @@
       "sourceSha256": "b80f08d7da013bfb353f2311c5fd513aca2dd2e892fad350bcae930a9f024611"
     }
   },
-  "ravenVersion": "2b3513f629de",
+  "ravenVersion": "8f5a4c3e67ae",
   "schema": 1,
   "template": "python",
-  "updatedAt": "2026-07-28T17:49:15.570205+00:00"
+  "updatedAt": "2026-07-28T19:30:55.310864+00:00"
 }

--- a/common/.raven/git-hooks/lib/check-ai-attribution-content.py
+++ b/common/.raven/git-hooks/lib/check-ai-attribution-content.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Block AI attribution mentions from leaking into staged/outbound file content.
+"""Block AI attribution mentions from leaking into staged/outbound content.
 
-The commit-msg hook only cleans commit *message* trailers -- an AI-authorship
-credit left in a source file or README (an AI tool named as the generator)
-would still reach history untouched. Unlike commit-msg, this fails the
-commit/push rather than silently editing tracked file content: there is no
+The commit-msg hook strips attribution *trailers* at commit time -- but an
+AI-authorship credit left in a source file or README (an AI tool named as the
+generator) would still reach history untouched. Unlike commit-msg, this fails
+the commit/push rather than silently editing tracked file content: there is no
 safe way to auto-rewrite an arbitrary line inside a source file.
+
+The `outbound --push-plan` path additionally scans commit *messages*, which
+commit-msg cannot vouch for. Stripping only happens when that hook ran, and it
+routinely does not: `git commit --no-verify`, `git cherry-pick` and `git
+rebase` reapplying pre-hook commits (neither runs commit-msg), and any clone
+made before the hooks were installed all land a trailer in history that
+strip-time never saw. Pre-push is where that is discoverable.
 
 Modes:
 
@@ -41,6 +48,20 @@ _CONTENT_PATTERN = re.compile(
     r"(?:generated|written|authored|implemented|drafted)\s+(?:by|with)\s+.*"
     r"(?:claude|copilot|codex|chatgpt|gpt-[0-9]+|gemini|llama|mistral"
     r"|@anthropic\.com|@openai\.com)",
+    re.IGNORECASE,
+)
+
+# Commit-message trailers, matched per line. Deliberately a copy of the
+# commit-msg hook's `_AI_TRAILER` rather than an import: that hook is a
+# standalone script with no dependency on this lib/ directory, and a partial
+# install must not be able to break it. `test_message_pattern_matches_the_
+# commit_msg_hook_pattern` pins the two together so they cannot drift.
+_MESSAGE_PATTERN = re.compile(
+    r"^(?:co-authored-by|generated-by):\s+.*"
+    r"(?:(?:claude|copilot|codex|chatgpt|gpt-[0-9]+|gemini|llama|mistral"
+    r"|@anthropic\.com|@openai\.com)"
+    r"|<noreply@[^>]+>)"
+    r"|^claude-session:\s+\S+",
     re.IGNORECASE,
 )
 
@@ -100,6 +121,21 @@ def _scan(added_lines: list[str], label: str) -> int:
         print(hit, file=sys.stderr)
     print(
         "remove generated-attribution mentions from newly added repository text",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _scan_messages(message_text: str, label: str) -> int:
+    hits = [line for line in message_text.splitlines() if _MESSAGE_PATTERN.match(line)]
+    if not hits:
+        return 0
+    print(f"Forbidden AI attribution trailer found in a commit message ({label}):", file=sys.stderr)
+    for hit in hits:
+        print(hit, file=sys.stderr)
+    print(
+        "amend or rebase the commit to drop the attribution trailer "
+        "(commit-msg strips these, but only when it runs)",
         file=sys.stderr,
     )
     return 1
@@ -174,6 +210,16 @@ def _remote_tracking_shas(remote: str) -> list[str]:
     return every.stdout.split()
 
 
+_UNBOUNDED_NOTICE = (
+    "note: no remote baseline -- this remote has no tracking refs in this clone, "
+    "so nothing is known to be already published and the scan covered the full "
+    "history rather than only new commits. The findings above may predate this "
+    "branch and may not be fixable without rewriting history. To publish anyway, "
+    "set block_ai_attribution_content = false under [git_hooks] in "
+    ".raven/config.toml."
+)
+
+
 def _scan_push_plan(plan_text: str, remote: str) -> int:
     """Scan the commits Git is actually pushing, per its own push plan.
 
@@ -196,6 +242,20 @@ def _scan_push_plan(plan_text: str, remote: str) -> int:
     that branch's content as newly added. The trade-off is that a merge commit
     contributes no patch of its own, leaving content introduced solely by a
     conflict resolution to the staged (pre-commit) scan.
+
+    The same revision set is scanned twice: once for file content and once for
+    commit messages, which the commit-msg hook can only vouch for on commits it
+    actually ran on.
+
+    When the remote has no tracking refs at all, the negative side is empty and
+    the walk does reach the root commit. That is intentional and pinned by test:
+    nothing is known to be published, so every reachable commit genuinely is
+    leaving the machine for the first time and scanning all of it is the correct
+    answer rather than a false positive. It is not the fail-open case -- the
+    scan is fully evaluable, just wide -- so findings are reported, with
+    `_UNBOUNDED_NOTICE` explaining why they may reach further back than the
+    push. Only unevaluable states (unresolvable object, failing git invocation)
+    skip.
     """
     positives: list[str] = []
     negatives: list[str] = []
@@ -221,16 +281,34 @@ def _scan_push_plan(plan_text: str, remote: str) -> int:
     # An exclusion tip that equals a pushed tip is kept, not dropped: it means the
     # remote already has that commit (e.g. pushing an existing tip under a new
     # branch name), and the correct outcome is an empty scan, not a full rescan.
-    args = ["log", "--no-color", "--format=%H", "--unified=0", "-p", *dict.fromkeys(positives)]
-    if negatives:
-        args += ["--not", *dict.fromkeys(negatives)]
-    args += ["--", "."]
-    log = _git(args)
-    if log.returncode != 0:
+    revs = list(dict.fromkeys(positives))
+    bounds = ["--not", *dict.fromkeys(negatives)] if negatives else []
+    label = f"outbound commits for {', '.join(pushed_refs)}"
+
+    content = _git(
+        ["log", "--no-color", "--format=%H", "--unified=0", "-p", *revs, *bounds, "--", "."]
+    )
+    if content.returncode != 0:
         # git could not walk the range (e.g. a corrupt or grafted object); skip
         # rather than block a push this hook cannot evaluate.
         return 0
-    return _scan(_added_lines(log.stdout), f"outbound commits for {', '.join(pushed_refs)}")
+    content_status = _scan(_added_lines(content.stdout), label)
+
+    # Messages get their own invocation rather than a widened --format on the one
+    # above: keeping the two streams apart means no delimiter has to survive
+    # adversarial patch text, and no patch line can be read as a message (or the
+    # reverse). No pathspec here -- every pushed commit's message counts,
+    # including a merge's, which contributes no patch of its own.
+    messages = _git(["log", "--no-color", "--no-patch", "--format=%B", *revs, *bounds])
+    message_status = 0
+    if messages.returncode == 0:
+        message_status = _scan_messages(messages.stdout, label)
+
+    if not (content_status or message_status):
+        return 0
+    if not bounds:
+        print(_UNBOUNDED_NOTICE, file=sys.stderr)
+    return 1
 
 
 _USAGE = "usage: check-ai-attribution-content.py {staged|outbound} [--push-plan] [--remote NAME]"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,7 +21,12 @@ def load_script_module(name: str, path: Path) -> Any:
     read and monkeypatch its attributes. Centralizing the import keeps the
     ``spec``/``loader`` None-checks in one Pyright-friendly place.
     """
-    spec = importlib.util.spec_from_file_location(name, path)
+    # The loader is passed explicitly so extensionless scripts load too: Raven's
+    # git hooks are named `commit-msg`/`pre-push`, and spec_from_file_location
+    # infers no loader for a path whose suffix it does not recognize.
+    spec = importlib.util.spec_from_file_location(
+        name, path, loader=SourceFileLoader(name, str(path))
+    )
     if spec is None or spec.loader is None:
         raise ImportError(f"could not load module {name!r} from {path}")
     module = importlib.util.module_from_spec(spec)
@@ -47,6 +52,20 @@ def attribution_line(tool: str = "Claude", verb: str = "Generated", prep: str = 
     string" edit in either copy would break the repo's own commit path.
     """
     return f"# {verb} {prep} {tool}\n"
+
+
+def trailer_line(
+    tool: str = "Claude",
+    key: str = "Co-Authored-By",
+    email: str = "dev@example.com",
+) -> str:
+    """Build an AI-attribution commit *message* trailer the scanners must reject.
+
+    Assembled at runtime for the same reason as ``attribution_line``: Raven's
+    own hooks run on this repository, and the commit-msg hook would strip a
+    literal trailer out of any commit that touched a file containing one.
+    """
+    return f"{key}: {tool} <{email}>\n"
 
 
 def push_plan_line(ref: str, local_sha: str, remote_sha: str) -> str:

--- a/tests/test_ai_attribution_content_hook.py
+++ b/tests/test_ai_attribution_content_hook.py
@@ -6,7 +6,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from helpers import REPO_ROOT, attribution_line, push_plan_line
+from helpers import (
+    REPO_ROOT,
+    attribution_line,
+    load_script_module,
+    push_plan_line,
+    trailer_line,
+)
 
 
 class AiAttributionContentHookTests(unittest.TestCase):
@@ -298,6 +304,127 @@ class AiAttributionContentHookTests(unittest.TestCase):
 
         self.assertEqual(rc, 1, err)
         self.assertIn("Claude", err)
+
+    def test_push_plan_blocks_attribution_trailer_in_commit_message(self):
+        # The commit-msg hook strips these, but stripping only happens when that
+        # hook ran. `--no-verify`, `git cherry-pick`, `git rebase` reapplying
+        # pre-hook commits, and clones made before install all put a trailer into
+        # history that never passed strip-time; pre-push is where that surfaces.
+        self._commit("README.md", "# repo\n")
+        base = self._rev_parse()
+        self._git("update-ref", "refs/remotes/origin/main", base)
+        self._commit("notes.py", "print('hi')\n", message="feat: thing\n\n" + trailer_line())
+
+        rc, err = self._run_plan(push_plan_line("refs/heads/main", self._rev_parse(), base))
+
+        self.assertEqual(rc, 1, err)
+        self.assertIn("Claude", err)
+        self.assertIn("commit message", err)
+
+    def test_push_plan_blocks_bare_noreply_trailer_in_commit_message(self):
+        # The `<noreply@...>` arm catches bots this pattern does not name.
+        self._commit("README.md", "# repo\n")
+        base = self._rev_parse()
+        self._git("update-ref", "refs/remotes/origin/main", base)
+        self._commit(
+            "notes.py",
+            "print('hi')\n",
+            message="feat: thing\n\n" + trailer_line(tool="Some Bot", email="noreply@example.test"),
+        )
+
+        rc, err = self._run_plan(push_plan_line("refs/heads/main", self._rev_parse(), base))
+
+        self.assertEqual(rc, 1, err)
+
+    def test_push_plan_allows_clean_commit_message(self):
+        # Negative control for the message gate: an ordinary human co-author
+        # trailer and an ordinary subject must not trip it.
+        self._commit("README.md", "# repo\n")
+        base = self._rev_parse()
+        self._git("update-ref", "refs/remotes/origin/main", base)
+        self._commit(
+            "notes.py",
+            "print('hi')\n",
+            message="feat: thing\n\n" + trailer_line(tool="A Human", email="human@example.com"),
+        )
+
+        rc, err = self._run_plan(push_plan_line("refs/heads/main", self._rev_parse(), base))
+
+        self.assertEqual(rc, 0, err)
+
+    def test_push_plan_message_scan_is_bounded_by_remote_tracking_refs(self):
+        # The message scan reuses the patch scan's revision bounds, so a trailer
+        # in an already-published ancestor is not re-reported on every later push.
+        self._commit("README.md", "# repo\n", message="old\n\n" + trailer_line())
+        published = self._rev_parse()
+        self._git("update-ref", "refs/remotes/origin/main", published)
+        self._commit("notes.py", "print('hi')\n", message="feat: clean")
+
+        rc, err = self._run_plan(push_plan_line("refs/heads/main", self._rev_parse(), published))
+
+        self.assertEqual(rc, 0, err)
+
+    def test_push_plan_scans_merge_commit_messages(self):
+        # A merge contributes no patch of its own, so the content scan cannot see
+        # it; the message scan is the only gate on a trailer in a merge message.
+        self._commit("README.md", "# repo\n")
+        base = self._rev_parse()
+        self._git("update-ref", "refs/remotes/origin/main", base)
+        self._git("checkout", "-q", "-b", "side")
+        self._commit("side.py", "print('side')\n")
+        self._git("checkout", "-q", "-")
+        self._commit("main.py", "print('main')\n")
+        self._git(
+            "merge",
+            "--no-ff",
+            "-q",
+            "-m",
+            "merge: side\n\n" + trailer_line(),
+            "side",
+        )
+
+        rc, err = self._run_plan(push_plan_line("refs/heads/merged", self._rev_parse(), base))
+
+        self.assertEqual(rc, 1, err)
+
+    def test_push_plan_unbounded_scan_explains_the_missing_remote_baseline(self):
+        # Behaviour stays as pinned by the full-history test above: scanning
+        # everything is correct when nothing is known to be published. What was
+        # missing is *why*, on the one push where a block is least actionable.
+        self._commit("README.md", "# repo\n")
+        self._commit("legacy.py", attribution_line("Gemini") + "print('legacy')\n")
+
+        rc, err = self._run_plan(
+            push_plan_line("refs/heads/brand-new", self._rev_parse(), self._ZERO_SHA)
+        )
+
+        self.assertEqual(rc, 1, err)
+        self.assertIn("no remote baseline", err)
+        self.assertIn("block_ai_attribution_content", err)
+
+    def test_bounded_scan_does_not_print_the_unbounded_notice(self):
+        # Negative control: the notice must not appear on an ordinary push.
+        self._commit("README.md", "# repo\n")
+        base = self._rev_parse()
+        self._git("update-ref", "refs/remotes/origin/main", base)
+        self._commit("notes.py", attribution_line("Claude") + "print('hi')\n")
+
+        rc, err = self._run_plan(push_plan_line("refs/heads/main", self._rev_parse(), base))
+
+        self.assertEqual(rc, 1, err)
+        self.assertNotIn("no remote baseline", err)
+
+    def test_message_pattern_matches_the_commit_msg_hook_pattern(self):
+        # The two gates must agree on what a forbidden trailer is. They are
+        # deliberately not shared by import: commit-msg has no dependency on
+        # lib/, so a partial install cannot break it. This pins them instead.
+        lib = load_script_module("ai_attribution_content_lib_for_pattern_check", self.SCRIPT_PATH)
+        hook = load_script_module(
+            "commit_msg_hook_for_pattern_check",
+            REPO_ROOT / "common" / ".raven" / "git-hooks" / "commit-msg",
+        )
+        self.assertEqual(lib._MESSAGE_PATTERN.pattern, hook._AI_TRAILER.pattern)
+        self.assertEqual(lib._MESSAGE_PATTERN.flags, hook._AI_TRAILER.flags)
 
     def test_script_is_executable(self):
         self.assertTrue(self.SCRIPT_PATH.stat().st_mode & 0o111)


### PR DESCRIPTION
Review feedback flagged two defects in `check-ai-attribution-content.py`. One
was real; the other turned out to be deliberate, tested behaviour. Both repros
were reproduced before deciding.

## 1. The push gate never scanned commit messages — fixed

`_scan_push_plan` runs `git log --format=%H -p` and `_added_lines` keeps only
`+`-prefixed patch lines, so no commit message ever reached the scanner. That
left `commit-msg` as the only gate on attribution trailers.

Verified bypasses (git 2.55), all of which land a trailer in history that
strip-time never saw:

- `git commit --no-verify`
- `git cherry-pick` — confirmed it does **not** run `commit-msg`
- `git rebase` reapplying pre-hook commits — same
- any clone made before the hooks were installed

**Fix:** scan the same revision set twice — once for content, once for
messages. The bounding is the hard part and is already computed, so the message
pass is one extra `git log`.

Two deliberate choices against the original suggestion:

- **Separate invocation, not a widened `--format` with a sentinel.** Keeping
  the streams apart means no delimiter has to survive adversarial patch text,
  and neither stream can be read as the other.
- **The pattern is a copy of `commit-msg`'s `_AI_TRAILER`, not an import.**
  `commit-msg` is a standalone script with no dependency on `lib/`; a partial
  install must not be able to break it — and this module already carries a
  comment worrying about hook/lib version skew. A test pins the two patterns
  byte-for-byte instead of coupling them.

The message pass carries no pathspec, which also closes the merge-commit gap
the content scan documents: a merge contributes no patch of its own, so its
message was previously unreachable from here.

## 2. "Fails closed on a first push" — not a defect, but under-explained

The claim was that an unbounded walk to the root commit contradicts the
module's fail-open contract. It does not:

- `tests/...:269` `test_push_plan_with_nothing_known_on_any_remote_scans_full_history`
  already pins this, with the rationale spelled out and a "pinned so it cannot
  change by accident" note.
- The fail-open contract covers *unevaluable* states (unresolvable object,
  absent plan, failing git invocation). This case is fully evaluable — git
  walks it fine and correctly answers "what is new to this remote?" On a first
  publish that answer is "all of it".
- The frequency argument was wrong on specifics. A first push to a **fork** is
  bounded, because `_remote_tracking_shas` falls back to all remotes when the
  named one has none — verified directly. The real trigger is narrower: zero
  tracking refs across *every* remote.
- The proposed fix (skip the scan) would leave the first-ever push of a new
  repo to a public host entirely unscanned — the highest-stakes push there is.

What was legitimate: the block is confusing, since findings can predate the
branch and may not be fixable without rewriting history. So the **verdict is
unchanged** and only the reporting changed — an explanatory stderr line naming
the missing baseline and the documented config escape. `_scan_push_plan`'s
docstring now states outright that the root-reaching walk is intentional and
is not the fail-open case.

## Tests

Eight added, each watched fail first, with the requested negative controls:

| Test | Proves |
|---|---|
| `..._blocks_attribution_trailer_in_commit_message` | vendor-named trailer blocks |
| `..._blocks_bare_noreply_trailer_in_commit_message` | the `<noreply@...>` arm |
| `..._allows_clean_commit_message` | **negative control** — human co-author trailer passes |
| `..._message_scan_is_bounded_by_remote_tracking_refs` | published ancestors are not re-reported |
| `..._scans_merge_commit_messages` | merge messages covered |
| `..._unbounded_scan_explains_the_missing_remote_baseline` | notice present |
| `test_bounded_scan_does_not_print_the_unbounded_notice` | **negative control** — ordinary push stays quiet |
| `test_message_pattern_matches_the_commit_msg_hook_pattern` | anti-drift between the two gates |

`load_script_module` now passes an explicit `SourceFileLoader` so extensionless
hooks (`commit-msg`) load. `trailer_line()` is built at runtime for the same
reason `attribution_line()` is — Raven's own hooks run on this repo.

## Verification

- Both original repros re-run against the patched script: #1 went `EXIT=0` →
  `EXIT=1` reporting the trailer; #2 stayed `EXIT=1` and now explains itself.
- `python scripts/self-check.py` — passes end to end (shape, dry-run, applied
  self-upgrade, convergence, ruff, tests).
- `python -m pytest tests` — 783 passed, 1 skipped, 299 subtests.
- `pyright` — 0 errors, 0 warnings.
- The push that opened this PR ran the new gate for real via `pre-push`.
